### PR TITLE
Add dockerfile for Swift 4.1.3 for Raspberry Pi 1 / Zero

### DIFF
--- a/rpi-armv6-swift-4.1.3-uraimo-ctx/rpi-armv6-debian-stretch-swift-4.1.3.dockerfile
+++ b/rpi-armv6-swift-4.1.3-uraimo-ctx/rpi-armv6-debian-stretch-swift-4.1.3.dockerfile
@@ -7,18 +7,17 @@ ARG TARBALL_FILE=swift-4.1.3-RPi01-RaspbianStretch.tgz
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-
 # Funny: libcurl3 provies libcurl.so.4 :-)
 # Maybe libpython3.5 makes libpython2.7 obsolete?
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
   git           \
   libedit2      \
   libpython2.7 libcurl3 libxml2 libicu-dev \
   libc6-dev \
   libatomic1  \
   libpython3.5 \
-  clang
+  clang \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Uraimo's tarball starts at /
 RUN curl -L -o $TARBALL_FILE $TARBALL_URL && tar -xvzf $TARBALL_FILE -C / && rm $TARBALL_FILE
@@ -29,9 +28,6 @@ RUN bash -c "echo '/usr/lib/swift/linux' > /etc/ld.so.conf.d/swift.conf;\
              ldconfig"
 
 RUN useradd -u 501 --create-home --shell /bin/bash swift
-
-RUN swift --version
-RUN swift package --version
 
 USER swift
 WORKDIR /home/swift

--- a/rpi-armv6-swift-4.1.3-uraimo-ctx/rpi-armv6-debian-stretch-swift-4.1.3.dockerfile
+++ b/rpi-armv6-swift-4.1.3-uraimo-ctx/rpi-armv6-debian-stretch-swift-4.1.3.dockerfile
@@ -1,0 +1,37 @@
+FROM balenalib/raspberry-pi-debian:stretch
+
+LABEL maintainer "Helge Heß <me@helgehess.eu>"
+
+ARG TARBALL_URL=https://www.dropbox.com/s/h6d2bwqs0gf997f/swift-4.1.3-RPi01-RaspbianStretch.tgz?dl=1
+ARG TARBALL_FILE=swift-4.1.3-RPi01-RaspbianStretch.tgz
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update
+
+# Funny: libcurl3 provies libcurl.so.4 :-)
+# Maybe libpython3.5 makes libpython2.7 obsolete?
+RUN apt-get install -y \
+  git           \
+  libedit2      \
+  libpython2.7 libcurl3 libxml2 libicu-dev \
+  libc6-dev \
+  libatomic1  \
+  libpython3.5 \
+  clang
+
+# Uraimo's tarball starts at /
+RUN curl -L -o $TARBALL_FILE $TARBALL_URL && tar -xvzf $TARBALL_FILE -C / && rm $TARBALL_FILE
+
+RUN bash -c "echo '/usr/lib/swift/linux' > /etc/ld.so.conf.d/swift.conf;\
+             echo '/usr/lib/swift/clang/lib/linux' >> /etc/ld.so.conf.d/swift.conf;\
+             echo '/usr/lib/swift/pm' >> /etc/ld.so.conf.d/swift.conf;\
+             ldconfig"
+
+RUN useradd -u 501 --create-home --shell /bin/bash swift
+
+RUN swift --version
+RUN swift package --version
+
+USER swift
+WORKDIR /home/swift


### PR DESCRIPTION
## Adds docker support for Swift 4.1.3 on RaspberryPi Zero or 1.

This uses Uraimo's prebuilt binary: https://www.uraimo.com/2018/06/13/A-big-update-on-Swift-4-1-2-for-raspberry-pi-zero-1-2-3/

The dockerfile is based on https://github.com/helje5/dockSwiftOnARM/blob/master/rpi-swift-4.1.x-uraimo-ctx/rpi-ubuntu-swift-4.1.x.dockerfile. 

I also had to add `clang` as a dependency and change `libicu55` to `libicu-dev` in order to get Swift / SPM running in the container.