### PR TITLE
Add Swift 4.2.2 images for Raspberry Pi 0/1/2/3 on Debian and Raspberry Pi 2/3 on Ubuntu

### DIFF
--- a/rpi-armv6-swift-4.2.2-uraimo-ctx/rpi-armv6-debian-stretch-swift-4.2.2.dockerfile
+++ b/rpi-armv6-swift-4.2.2-uraimo-ctx/rpi-armv6-debian-stretch-swift-4.2.2.dockerfile
@@ -1,0 +1,33 @@
+FROM balenalib/raspberry-pi-debian:stretch
+
+LABEL maintainer "Helge Heß <me@helgehess.eu>"
+
+ARG TARBALL_URL=https://www.dropbox.com/s/08aem3xndyfafdi/swift-4.2.2-RPi01-RaspbianStretch.tgz?dl=1
+ARG TARBALL_FILE=swift-4.2.2-RPi01-RaspbianStretch.tgz
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Funny: libcurl3 provies libcurl.so.4 :-)
+# Maybe libpython3.5 makes libpython2.7 obsolete?
+RUN apt-get update && apt-get install -y \
+  git           \
+  libedit2      \
+  libpython2.7 libcurl3 libxml2 libicu-dev \
+  libc6-dev \
+  libatomic1  \
+  libpython3.5 \
+  clang \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Uraimo's tarball starts at /
+RUN curl -L -o $TARBALL_FILE $TARBALL_URL && tar -xvzf $TARBALL_FILE -C / && rm $TARBALL_FILE
+
+RUN bash -c "echo '/usr/lib/swift/linux' > /etc/ld.so.conf.d/swift.conf;\
+             echo '/usr/lib/swift/clang/lib/linux' >> /etc/ld.so.conf.d/swift.conf;\
+             echo '/usr/lib/swift/pm' >> /etc/ld.so.conf.d/swift.conf;\
+             ldconfig"
+
+RUN useradd -u 501 --create-home --shell /bin/bash swift
+
+USER swift
+WORKDIR /home/swift

--- a/rpi-swift-4.2.2-uraimo-ctx/rpi-debian-swift-4.2.2.dockerfile
+++ b/rpi-swift-4.2.2-uraimo-ctx/rpi-debian-swift-4.2.2.dockerfile
@@ -1,0 +1,33 @@
+FROM balenalib/raspberrypi3-debian:stretch
+
+LABEL maintainer "Helge Heß <me@helgehess.eu>"
+
+ARG TARBALL_URL=https://www.dropbox.com/s/b9gizkdqifhqcdh/swift-4.2.2-RPi23-RaspbianStretch.tgz?dl=1
+ARG TARBALL_FILE=swift-4.2.2-RPi23-RaspbianStretch
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Funny: libcurl3 provies libcurl.so.4 :-)
+# Maybe libpython3.5 makes libpython2.7 obsolete?
+RUN apt-get update && apt-get install -y \
+  git           \
+  libedit2      \
+  libpython2.7 libcurl3 libxml2 libicu-dev \
+  libc6-dev \
+  libatomic1  \
+  libpython3.5 \
+  clang \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Uraimo's tarball starts at /
+RUN curl -L -o $TARBALL_FILE $TARBALL_URL && tar -xvzf $TARBALL_FILE -C / && rm $TARBALL_FILE
+
+RUN bash -c "echo '/usr/lib/swift/linux' > /etc/ld.so.conf.d/swift.conf;\
+             echo '/usr/lib/swift/clang/lib/linux' >> /etc/ld.so.conf.d/swift.conf;\
+             echo '/usr/lib/swift/pm' >> /etc/ld.so.conf.d/swift.conf;\
+             ldconfig"
+
+RUN useradd -u 501 --create-home --shell /bin/bash swift
+
+USER swift
+WORKDIR /home/swift

--- a/rpi-swift-4.2.2-uraimo-ctx/rpi-ubuntu-swift-4.2.2.dockerfile
+++ b/rpi-swift-4.2.2-uraimo-ctx/rpi-ubuntu-swift-4.2.2.dockerfile
@@ -1,0 +1,33 @@
+FROM ioft/armhf-ubuntu:16.04
+
+LABEL maintainer "Helge Heß <me@helgehess.eu>"
+
+ARG TARBALL_URL=https://www.dropbox.com/s/qnf7p988lp46mlq/swift-4.2.2-RPi23-Ubuntu1604.tgz?dl=1
+ARG TARBALL_FILE=swift-4.2.2-RPi23-Ubuntu1604.tgz
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Maybe libpython3.5 makes libpython2.7 obsolete?
+RUN apt-get update && apt-get install -y \
+  git           \
+  libedit2      \
+  libpython2.7 libcurl3-nss libxml2 libicu55 \
+  libc6-dev \
+  libatomic1    \
+  libpython3.5 \
+  clang \
+  curl \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Uraimo's tarball starts at /
+RUN curl -L -o $TARBALL_FILE $TARBALL_URL && tar -xvzf $TARBALL_FILE -C / && rm $TARBALL_FILE
+
+RUN bash -c "echo '/usr/lib/swift/linux' > /etc/ld.so.conf.d/swift.conf;\
+             echo '/usr/lib/swift/clang/lib/linux' >> /etc/ld.so.conf.d/swift.conf;\
+             echo '/usr/lib/swift/pm' >> /etc/ld.so.conf.d/swift.conf;\
+             ldconfig"
+
+RUN useradd -u 501 --create-home --shell /bin/bash swift
+
+USER swift
+WORKDIR /home/swift


### PR DESCRIPTION
These images use [Uraimo's 4.2.2 binaries](https://github.com/uraimo/buildSwiftOnARM/tree/4.2.2#status).

### Raspberry Pi 0/1/2/3 on Debian
There is one image specific to RPi 0/1 (ARMv6) and another image for RPi 2/3 (ARMv7). Both of these images are modeled after [PR #2: Add dockerfile for Swift 4.1.3 for Raspberry Pi 1 / Zero](#2).

### Raspberry Pi 2/3 on Ubuntu
The Ubuntu image is modeled after [rpi-ubuntu-swift-4.1.x.dockerfile](https://github.com/helje5/dockSwiftOnARM/blob/master/rpi-swift-4.1.x-uraimo-ctx/rpi-ubuntu-swift-4.1.x.dockerfile).

I had to add `clang` and replace `libcurl3` with `libcurl3-nss`. I also added `curl` to download Uraimo's tarball.




